### PR TITLE
testIdのMax値を変更

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -5,7 +5,7 @@
 <p>genre (string, required) - ジャンル名。50文字以内</p>
 </li>
 <li>
-<p>testId (int, required) - テストID。11文字以内</p>
+<p>testId (int, required) - テストID。999以下</p>
 </li>
 </ul>
 <h4>Example URI</h4><div class="definition"><span class="method post">POST</span>&nbsp;<span class="uri"><span class="hostname"></span>/onigiri-tests</span></div><div class="title"><strong>Request</strong><div class="collapse-button"><span class="close">Hide</span><span class="open">Show</span></div></div><div class="collapse-content"><div class="inner"><h5>Headers</h5><pre><code><span class="hljs-attribute">Content-Type</span>: <span class="hljs-string">application/json</span></code></pre><div style="height: 1px;"></div><h5>Body</h5><pre><code>{
@@ -35,7 +35,7 @@
       "<span class="hljs-attribute">field</span>":<span class="hljs-value"><span class="hljs-string">"testId"</span></span>,
       "<span class="hljs-attribute">messages</span>":<span class="hljs-value">[
         <span class="hljs-string">"cannot be null"</span>,
-        <span class="hljs-string">"maximum length is 11"</span>,
+        <span class="hljs-string">"maximum value is 999"</span>,
       ]
     </span>}
   ]

--- a/md/onigiri-happy-nihonngo-api.md
+++ b/md/onigiri-happy-nihonngo-api.md
@@ -10,7 +10,7 @@ FORMAT: 1A
 以下のパラメータをJSON形式で送信します。
 
 + genre (string, required) - ジャンル名。50文字以内
-+ testId (int, required) - テストID。11文字以内
++ testId (int, required) - テストID。999以下
 
 + Request (application/json)
   {
@@ -48,7 +48,7 @@ FORMAT: 1A
               "field":"testId",
               "messages":[
                 "cannot be null",
-                "maximum length is 11",
+                "maximum value is 999",
               ]
             }
           ]


### PR DESCRIPTION
# 概要
testIdの文字制限が11桁以内で桁数が大きすぎたので、最大値を999とした。